### PR TITLE
Fixed url for Let's Encrypt.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get '/pages' => 'pages#index'
   get '/next-event-is-still-planned' => 'staticpages#next_event_is_still_planned'
   get '/ninjas-works' => 'staticpages#ninjas_works'
-  get ".well-known/acme-challenge/:id" => "staticpages#letsencrypt"
+  get "/.well-known/acme-challenge/:id" => "staticpages#letsencrypt"
 
   resources :pages, only: [:show], :path => '/'
 


### PR DESCRIPTION
- URL の typo を修正
